### PR TITLE
增加繁體中文翻譯轉轉換

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -18,17 +19,23 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildToolsVersion '26.0.2'
 }
+
 greendao{
     schemaVersion 3
     daoPackage 'com.example.newbiechen.ireader.model.gen'
     targetGenDir 'src/main/java'
+}
+
+repositories {
+    maven {
+        url 'https://dl.bintray.com/qichuan/maven/'
+    }
 }
 
 dependencies {
@@ -57,6 +64,9 @@ dependencies {
     // ORM Database
     implementation "org.greenrobot:greendao:$rootProject.greendaoVersion"
     testImplementation "junit:junit:$rootProject.junitVersion"
+
+    // OpenCC to convert Simp. Chinese to Trad. Chinese
+    implementation "com.zqc.opencc.android.lib:lib-opencc-android:0.8.0@aar"
 
     // AndroidTagGroup
     implementation 'me.gujun.android.taggroup:library:1.4@aar'

--- a/app/src/main/java/com/example/newbiechen/ireader/model/bean/CollBookBean.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/model/bean/CollBookBean.java
@@ -5,6 +5,8 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
 
+import com.example.newbiechen.ireader.App;
+import com.example.newbiechen.ireader.utils.StringUtils;
 import com.google.gson.annotations.SerializedName;
 
 import org.greenrobot.greendao.annotation.Entity;
@@ -106,7 +108,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getTitle() {
-        return title;
+        return StringUtils.convertCC(title, App.getContext());
     }
 
     public void setTitle(String title) {
@@ -114,7 +116,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getAuthor() {
-        return author;
+        return StringUtils.convertCC(author, App.getContext());
     }
 
     public void setAuthor(String author) {
@@ -122,7 +124,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getShortIntro() {
-        return shortIntro;
+        return StringUtils.convertCC(shortIntro, App.getContext());
     }
 
     public void setShortIntro(String shortIntro) {
@@ -130,7 +132,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getCover() {
-        return cover;
+        return StringUtils.convertCC(cover, App.getContext());
     }
 
     public void setCover(String cover) {
@@ -162,7 +164,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getUpdated() {
-        return updated;
+        return StringUtils.convertCC(updated, App.getContext());
     }
 
     public void setUpdated(String updated) {
@@ -178,7 +180,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getLastChapter() {
-        return lastChapter;
+        return StringUtils.convertCC(lastChapter, App.getContext());
     }
 
     public void setLastChapter(String lastChapter) {
@@ -214,7 +216,7 @@ public class CollBookBean implements Parcelable{
     }
 
     public String getLastRead() {
-        return lastRead;
+        return StringUtils.convertCC(lastRead, App.getContext());
     }
 
     public void setLastRead(String lastRead) {

--- a/app/src/main/java/com/example/newbiechen/ireader/model/local/ReadSettingManager.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/model/local/ReadSettingManager.java
@@ -28,6 +28,7 @@ public class ReadSettingManager {
     public static final String SHARED_READ_NIGHT_MODE = "shared_night_mode";
     public static final String SHARED_READ_VOLUME_TURN_PAGE = "shared_read_volume_turn_page";
     public static final String SHARED_READ_FULL_SCREEN = "shared_read_full_screen";
+    public static final String SHARED_READ_CONVERT_TYPE = "shared_read_convert_type";
 
     private static volatile ReadSettingManager sInstance;
 
@@ -120,5 +121,13 @@ public class ReadSettingManager {
 
     public boolean isFullScreen() {
         return sharedPreUtils.getBoolean(SHARED_READ_FULL_SCREEN, false);
+    }
+
+    public void setConvertType(int convertType) {
+        sharedPreUtils.putInt(SHARED_READ_CONVERT_TYPE, convertType);
+    }
+
+    public int getConvertType() {
+        return sharedPreUtils.getInt(SHARED_READ_CONVERT_TYPE, 0);
     }
 }

--- a/app/src/main/java/com/example/newbiechen/ireader/ui/activity/MoreSettingActivity.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/ui/activity/MoreSettingActivity.java
@@ -67,7 +67,6 @@ public class MoreSettingActivity extends BaseActivity{
     private void initSwitchStatus(){
         mScVolume.setChecked(isVolumeTurnPage);
         mScFullScreen.setChecked(isFullScreen);
-        mScConvertType.setSelection(convertType);
     }
 
     @Override
@@ -108,6 +107,9 @@ public class MoreSettingActivity extends BaseActivity{
                 R.array.conversion_type_array, android.R.layout.simple_spinner_item);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mScConvertType.setAdapter(adapter);
+
+        // initSwitchStatus() be called earlier than onCreate(), so setSelection() won't work
+        mScConvertType.setSelection(convertType);
 
         mScConvertType.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override

--- a/app/src/main/java/com/example/newbiechen/ireader/ui/activity/MoreSettingActivity.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/ui/activity/MoreSettingActivity.java
@@ -4,12 +4,17 @@ import android.os.Bundle;
 import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
 import android.widget.RelativeLayout;
+import android.widget.Spinner;
+import android.view.View;
 
 import com.example.newbiechen.ireader.R;
 import com.example.newbiechen.ireader.model.local.ReadSettingManager;
 import com.example.newbiechen.ireader.ui.base.BaseActivity;
 
 import butterknife.BindView;
+
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 
 /**
  * Created by newbiechen on 17-6-6.
@@ -25,9 +30,14 @@ public class MoreSettingActivity extends BaseActivity{
     RelativeLayout mRlFullScreen;
     @BindView(R.id.more_setting_sc_full_screen)
     SwitchCompat mScFullScreen;
+    @BindView(R.id.more_setting_rl_convert_type)
+    RelativeLayout mRlConvertType;
+    @BindView(R.id.more_setting_sc_convert_type)
+    Spinner mScConvertType;
     private ReadSettingManager mSettingManager;
     private boolean isVolumeTurnPage;
     private boolean isFullScreen;
+    private int convertType;
     @Override
     protected int getContentId() {
         return R.layout.activity_more_setting;
@@ -39,6 +49,7 @@ public class MoreSettingActivity extends BaseActivity{
         mSettingManager = ReadSettingManager.getInstance();
         isVolumeTurnPage = mSettingManager.isVolumeTurnPage();
         isFullScreen = mSettingManager.isFullScreen();
+        convertType = mSettingManager.getConvertType();
     }
 
     @Override
@@ -56,6 +67,7 @@ public class MoreSettingActivity extends BaseActivity{
     private void initSwitchStatus(){
         mScVolume.setChecked(isVolumeTurnPage);
         mScFullScreen.setChecked(isFullScreen);
+        mScConvertType.setSelection(convertType);
     }
 
     @Override
@@ -86,5 +98,27 @@ public class MoreSettingActivity extends BaseActivity{
                     mSettingManager.setFullScreen(isFullScreen);
                 }
         );
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this,
+                R.array.conversion_type_array, android.R.layout.simple_spinner_item);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mScConvertType.setAdapter(adapter);
+
+        mScConvertType.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                mSettingManager.setConvertType(position);
+                convertType = position;
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
     }
 }

--- a/app/src/main/java/com/example/newbiechen/ireader/ui/activity/ReadActivity.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/ui/activity/ReadActivity.java
@@ -386,6 +386,9 @@ public class ReadActivity extends BaseMVPActivity<ReadContract.Presenter>
 
                     @Override
                     public void onCategoryFinish(List<TxtChapter> chapters) {
+                        for (TxtChapter chapter : chapters) {
+                            chapter.setTitle(StringUtils.convertCC(chapter.getTitle(), mPvPage.getContext()));
+                        }
                         mCategoryAdapter.refreshItems(chapters);
                     }
 

--- a/app/src/main/java/com/example/newbiechen/ireader/utils/Constant.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/utils/Constant.java
@@ -19,6 +19,7 @@ public class Constant {
     public static final String SHARED_SEX = "sex";
     public static final String SHARED_SAVE_BOOK_SORT = "book_sort";
     public static final String SHARED_SAVE_BILLBOARD = "billboard";
+    public static final String SHARED_CONVERT_TYPE = "convert_type";
     public static final String SEX_BOY = "boy";
     public static final String SEX_GIRL = "girl";
 

--- a/app/src/main/java/com/example/newbiechen/ireader/utils/StringUtils.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/utils/StringUtils.java
@@ -148,6 +148,9 @@ public class StringUtils {
         ConversionType currentConversionType = ConversionType.S2TWP;
         int convertType = SharedPreUtils.getInstance().getInt(SHARED_READ_CONVERT_TYPE, 0);
 
+        if (input.length() == 0)
+            return "";
+
         switch (convertType) {
             case 1:
                 currentConversionType = ConversionType.TW2SP;

--- a/app/src/main/java/com/example/newbiechen/ireader/utils/StringUtils.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/utils/StringUtils.java
@@ -1,7 +1,6 @@
 package com.example.newbiechen.ireader.utils;
 
 import android.support.annotation.StringRes;
-import android.util.Log;
 
 import com.example.newbiechen.ireader.App;
 
@@ -10,6 +9,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+
+import android.content.Context;
+import com.zqc.opencc.android.lib.ChineseConverter;
+import com.zqc.opencc.android.lib.ConversionType;
+
+import static com.example.newbiechen.ireader.model.local.ReadSettingManager.SHARED_READ_CONVERT_TYPE;
 
 /**
  * Created by newbiechen on 17-4-22.
@@ -135,5 +140,47 @@ public class StringUtils {
                 c[i] = (char) (c[i] - 65248);
         }
         return new String(c);
+    }
+
+    //繁簡轉換
+    public static String convertCC(String input, Context context)
+    {
+        ConversionType currentConversionType = ConversionType.S2TWP;
+        int convertType = SharedPreUtils.getInstance().getInt(SHARED_READ_CONVERT_TYPE, 0);
+
+        switch (convertType) {
+            case 1:
+                currentConversionType = ConversionType.TW2SP;
+                break;
+            case 2:
+                currentConversionType = ConversionType.S2HK;
+                break;
+            case 3:
+                currentConversionType = ConversionType.S2T;
+                break;
+            case 4:
+                currentConversionType = ConversionType.S2TW;
+                break;
+            case 5:
+                currentConversionType = ConversionType.S2TWP;
+                break;
+            case 6:
+                currentConversionType = ConversionType.T2HK;
+                break;
+            case 7:
+                currentConversionType = ConversionType.T2S;
+                break;
+            case 8:
+                currentConversionType = ConversionType.T2TW;
+                break;
+            case 9:
+                currentConversionType = ConversionType.TW2S;
+                break;
+            case 10:
+                currentConversionType = ConversionType.HK2S;
+                break;
+        }
+
+        return (convertType != 0)?ChineseConverter.convert(input, currentConversionType, context):input;
     }
 }

--- a/app/src/main/java/com/example/newbiechen/ireader/widget/page/PageLoader.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/widget/page/PageLoader.java
@@ -686,6 +686,7 @@ public abstract class PageLoader {
         // 获取章节的文本流
         BufferedReader reader = getChapterReader(chapter);
         List<TxtPage> chapters = loadPages(chapter, reader);
+
         return chapters;
     }
 
@@ -1240,6 +1241,7 @@ public abstract class PageLoader {
         String paragraph = chapter.getTitle();//默认展示标题
         try {
             while (showTitle || (paragraph = br.readLine()) != null) {
+                paragraph = StringUtils.convertCC(paragraph, mContext);
                 // 重置段落
                 if (!showTitle) {
                     paragraph = paragraph.replaceAll("\\s", "");
@@ -1264,7 +1266,7 @@ public abstract class PageLoader {
                         // 创建Page
                         TxtPage page = new TxtPage();
                         page.position = pages.size();
-                        page.title = chapter.getTitle();
+                        page.title = StringUtils.convertCC(chapter.getTitle(), mContext);
                         page.lines = new ArrayList<>(lines);
                         page.titleLines = titleLinesCount;
                         pages.add(page);
@@ -1317,7 +1319,7 @@ public abstract class PageLoader {
                 //创建Page
                 TxtPage page = new TxtPage();
                 page.position = pages.size();
-                page.title = chapter.getTitle();
+                page.title = StringUtils.convertCC(chapter.getTitle(), mContext);
                 page.lines = new ArrayList<>(lines);
                 page.titleLines = titleLinesCount;
                 pages.add(page);

--- a/app/src/main/res/layout/activity_more_setting.xml
+++ b/app/src/main/res/layout/activity_more_setting.xml
@@ -3,7 +3,7 @@
 	android:orientation="vertical"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
-	
+
 	<include layout="@layout/toolbar" />
 	
 	<RelativeLayout
@@ -31,11 +31,6 @@
 			android:longClickable="false"/>
 	</RelativeLayout>
 	
-	<View
-		android:layout_width="match_parent"
-		android:layout_height="1dp"
-		android:background="@color/nb.divider.narrow" />
-	
 	<RelativeLayout
 		android:id="@+id/more_setting_rl_full_screen"
 		android:layout_width="match_parent"
@@ -44,7 +39,7 @@
 		android:paddingLeft="20dp"
 		android:paddingRight="20dp"
 		android:background="@drawable/selector_common_bg">
-		
+
 		<TextView
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
@@ -57,6 +52,31 @@
 			android:layout_height="wrap_content"
 			android:layout_centerVertical="true"
 			android:layout_alignParentRight="true"
+			android:clickable="false"
+			android:longClickable="false"/>
+	</RelativeLayout>
+
+	<RelativeLayout
+		android:id="@+id/more_setting_rl_convert_type"
+		android:layout_width="match_parent"
+		android:layout_height="60dp"
+		android:gravity="center"
+		android:paddingLeft="20dp"
+		android:paddingRight="20dp"
+		android:background="@drawable/selector_common_bg">
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_centerVertical="true"
+			android:text="繁簡轉換"/>
+
+		<android.support.v7.widget.AppCompatSpinner
+			android:id="@+id/more_setting_sc_convert_type"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_centerVertical="true"
+			android:layout_alignParentEnd="true"
 			android:clickable="false"
 			android:longClickable="false"/>
 	</RelativeLayout>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -186,4 +186,18 @@
     <!--BookShelf-->
     <string name="nb.bookshelf.book_not_exist">文件不存在或者内容為空,是否刪除?</string>
 
+    <!--OpenCC-->
+    <string-array name="conversion_type_array">
+        <item>不轉換</item>
+        <item>臺灣正體到簡體(大陸常用詞彙)</item>
+        <item>簡體到香港繁體</item>
+        <item>簡體到繁體</item>
+        <item>簡體到臺灣正體</item>
+        <item>簡體到繁體(臺灣常用詞彙)</item>
+        <item>繁體到香港繁體</item>
+        <item>繁體到簡體</item>
+        <item>繁體臺灣正體</item>
+        <item>臺灣正體到簡體</item>
+        <item>香港繁體到簡體</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,189 @@
+<resources>
+    <string name="app_name">IReader</string>
+    <string name="nb.title.app">iReader</string>
+
+    <!--string_array-->
+    <string-array name="nb_fragment_title">
+        <item>@string/nb.fragment.title.bookshelf</item>
+        <item>@string/nb.fragment.title.community</item>
+        <item>@string/nb.fragment.title.find</item>
+    </string-array>
+
+    <string-array name="nb_fragment_section">
+        <item>@string/nb.fragment.community.comment</item>
+        <item>@string/nb.fragment.community.discussion</item>
+        <item>@string/nb.fragment.community.help</item>
+        <item>@string/nb.fragment.community.girl</item>
+        <item>@string/nb.fragment.community.compose</item>
+    </string-array>
+
+    <!--榜单分类-->
+    <string-array name="nb_fragment_bill_book">
+        <item>周榜</item>
+        <item>月榜</item>
+        <item>總榜</item>
+    </string-array>
+    
+    <!--CollBook的长按点击-->
+    <string-array name="nb_menu_net_book">
+        <item>@string/nb.menu.action.top</item>
+        <item>@string/nb.menu.action.cache</item>
+        <item>@string/nb.menu.action.delete</item>
+        <item>@string/nb.menu.action.batch_manage</item>
+    </string-array>
+    
+    <string-array name="nb_menu_local_book">
+        <item>@string/nb.menu.action.top</item>
+        <item>@string/nb.menu.action.delete</item>
+        <item>@string/nb.menu.action.batch_manage</item>
+    </string-array>
+    
+    <!--常用-->
+    <string name="nb.common.tip">提示</string>
+    <string name="nb.common.sure">確定</string>
+    <string name="nb.common.cancel">取消</string>
+    
+    <!--网络相关-->
+    
+    <string name="nb.net.error_tip">似乎沒有網路哦</string>
+    
+    <!--fragment_title:主页的名字-->
+    <string name="nb.fragment.title.bookshelf">書架</string>
+    <string name="nb.fragment.title.community">社區</string>
+    <string name="nb.fragment.title.find">發現</string>
+
+    <!--fragment-->
+    <string name="nb.fragment.community.comment">綜合討論區</string>
+    <string name="nb.fragment.community.discussion">書評區</string>
+    <string name="nb.fragment.community.help">書荒幫助區</string>
+    <string name="nb.fragment.community.girl">女生區</string>
+    <string name="nb.fragment.community.compose">原創區</string>
+    
+    <!--fragment 主题书单-->
+    <string name="nb.fragment.book_list.hot">本周最熱</string>
+    <string name="nb.fragment.book_list.newest">最新發佈</string>
+    <string name="nb.fragment.book_list.collect">最多收藏</string>
+    
+    <string name="nb.fragment.book_list.message">共%1$d本書 |&#160; %2$d人收藏</string>
+    
+    <!--评论相关-->
+    <string name="nb.comment.floor">%1$d楼&#160;</string>
+    <string name="nb.comment.like_count">❤%1$d次同感</string>
+    <string name="nb.comment.best_comment">仰望神評論</string>
+    <string name="nb.comment.comment_count">共%1$d條評論</string>
+    <string name="nb.comment.reply_floor">(%1$d樓)</string>
+    <string name="nb.comment.reply_nickname">回復 %1$s</string>
+    <string name="nb.comment.empty_comment">佔無評論</string>
+    
+    <!--书评区相关-->
+    <string name="nb.review.book_type">[%1$s]</string>
+    <string name="nb.review.recommend">%1$d 人推薦</string>
+    <string name="nb.review.helpful">有用</string>
+    <string name="nb.review.unhelpful">無用</string>
+    <string name="nb.review.book_score">給書評打分</string>
+    <string name="nb.review.master_score">樓主打分：</string>
+    
+    
+    <!--find-->
+    <string name="nb.fragment.find.top">排行榜</string>
+    <string name="nb.fragment.find.topic">主題書單</string>
+    <string name="nb.fragment.find.sort">分類</string>
+    <string name="nb.fragment.find.listen">有聲小說</string>
+
+    <!--dialog-->
+    <string name="nb.dialog.text.introduce">我們會根據您的喜好\n推薦相對應的小說</string>
+    <string name="nb.dialog.text.choose_tip">--請選擇你的喜好--</string>
+    <string name="nb.dialog.text.boy_story">男生小說</string>
+    <string name="nb.dialog.text.girl_story">女生小說</string>
+    
+    <!--menu-->
+    <string name="nb.menu.action.search">搜索</string>
+    <string name="nb.menu.action.login">請登錄</string>
+    <string name="nb.menu.action.message">我的消息</string>
+    <string name="nb.menu.action.download">下載列表</string>
+    <string name="nb.menu.action.sync">同步書架</string>
+    <string name="nb.menu.action.scan">掃描本地書籍</string>
+    <string name="nb.menu.action.transfer">WIFI傳書</string>
+    <string name="nb.menu.action.feedback">意見反饋</string>
+    <string name="nb.menu.action.night_mode">夜間模式</string>
+    <string name="nb.menu.action.setting">設置</string>
+    
+    <string name="nb.menu.action.top">置頂</string>
+    <string name="nb.menu.action.cache">緩存</string>
+    <string name="nb.menu.action.delete">刪除</string>
+    <string name="nb.menu.action.batch_manage">批量管理</string>
+    
+    <!--SplashActivity-->
+    <string name="nb.splash.skip">跳過</string>
+
+    <!--user:用户的信息-->
+    <string name="nb.user.lv">&#160;lv.%1$d</string>
+    <!--book:书籍的信息-->
+    <string name="nb.book.type">[%1$s]</string>
+    <string name="nb.book.recommend">%1$d 人推薦</string>
+    <string name="nb.book.message">%1$d人在追 |&#160; %2$s%%讀者留存</string>
+    <string name="nb.book.word">|&#160;%1$d&#160;萬字</string>
+    <!--sort:每类的书-->
+    <string name="nb.sort.book_count">%1$d 本</string>
+    
+    <!--tag: 标签-->
+    <string name="nb.tag.all">全部</string>
+    <string name="nb.tag.sex">性别</string>
+    <string name="nb.tag.boy">男生</string>
+    <string name="nb.tag.girl">女生</string>
+    
+    
+    <!--book_detail : -->
+    <string name="nb.book_detail.hot_comment">熱門書評</string>
+    <string name="nb.book_detail.community">%1$s的社區</string>
+    <string name="nb.book_detail.posts_count">共有%1$d個帖子</string>
+    <string name="nb.book_detail.recommend_book_list">推薦書單</string>
+    <string name="nb.book_detail.chase_update">追更</string>
+    <string name="nb.book_detail.give_up">放棄</string>
+    <string name="nb.book_detail.start_read">開始閱讀</string>
+    
+    <!--DownloadTask:书籍下载-->
+    <string name="nb.download.add_succeed">成功添加到下載列表</string>
+    <string name="nb.download.exist">該任務已存在</string>
+    <string name="nb.download.load_all">以緩存全部章節</string>
+    <string name="nb.download.progress">%1$d/%2$d</string>
+    <string name="nb.download.chapter_scope">(%1$d-%2$d章)</string>
+    
+    <string name="nb.download.start">繼續</string>
+    <string name="nb.download.pause">暫停</string>
+    <string name="nb.download.wait">等待</string>
+    <string name="nb.download.error">錯誤</string>
+    <string name="nb.download.finish">完成</string>
+    
+    <string name="nb.download.loading">下載中</string>
+    <string name="nb.download.waiting">等待中</string>
+    <string name="nb.download.pausing">暫停中</string>
+    <string name="nb.download.complete">已完成</string>
+    <string name="nb.download.source_error">資源或網路錯誤</string>
+    
+    <!--mode-->
+    <string name="nb.mode.night">夜間</string>
+    <string name="nb.mode.morning">日間</string>
+    
+    <!--read-->
+    <string name="nb.read.community">社區</string>
+    <string name="nb.read.brief">簡介</string>
+    <string name="nb.read.setting">設置</string>
+    <string name="nb.read.download">緩存</string>'
+    <string name="nb.read.category">目錄</string>
+    <string name="nb.read.no_chapter">第 %1$d 章(%2$d)</string>
+    
+    <!--file system-->
+    <string name="nb.file.sub_count">%1$d 項</string>
+    <string name="nb.file.path">存儲卡:%1$s</string>
+    <string name="nb.file.add_shelf">加入書架</string>
+    <string name="nb.file.add_shelves">加入書架(%1$d)</string>
+    <string name="nb.file.add_succeed">成功添加%1$d本書</string>
+    
+    <!--search-->
+    <string name="nb.search.book.brief">%1$d人在追 | %2$s讀者留存 | %3$s著</string>
+
+    <!--BookShelf-->
+    <string name="nb.bookshelf.book_not_exist">文件不存在或者内容為空,是否刪除?</string>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,5 +186,18 @@
     <!--BookShelf-->
     <string name="nb.bookshelf.book_not_exist">文件不存在或者内容为空,是否删除?</string>
 
-
+    <!--OpenCC-->
+    <string-array name="conversion_type_array">
+        <item>不轉換</item>
+        <item>臺灣正體到簡體(大陸常用詞彙)</item>
+        <item>簡體到香港繁體</item>
+        <item>簡體到繁體</item>
+        <item>簡體到臺灣正體</item>
+        <item>簡體到繁體(臺灣常用詞彙)</item>
+        <item>繁體到香港繁體</item>
+        <item>繁體到簡體</item>
+        <item>繁體臺灣正體</item>
+        <item>臺灣正體到簡體</item>
+        <item>香港繁體到簡體</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
1. 加入繁體中文翻譯 介面可自動轉為繁體中文 假如手機語系設為台灣
2. 加入繁簡轉換設置 可在閱讀設置更改 使用 OpenCC 可轉換多種繁體詞彙
     臺灣正體到簡體(大陸常用詞彙) 
     簡體到香港繁體 
      簡體到繁體 
      簡體到臺灣正體 
      簡體到繁體(臺灣常用詞彙) 
      繁體到香港繁體 
      繁體到簡體 
      繁體臺灣正體 
      臺灣正體到簡體 
      香港繁體到簡體 