### PR TITLE
修正在 MainActivity 跟 ReadActivity 旋轉時會 crash 的問題

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         <activity android:name=".ui.activity.SplashActivity"
             android:theme="@style/SplashTheme">
         </activity>
-        <activity android:name=".ui.activity.MainActivity">
+        <activity android:name=".ui.activity.MainActivity" android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -35,8 +35,7 @@
         <activity android:name=".ui.activity.OtherBillBookActivity"/>
         <activity android:name=".ui.activity.BookDetailActivity"/>
         <activity android:name=".ui.activity.DownloadActivity"/>
-        <activity android:name=".ui.activity.ReadActivity">
-        </activity>
+        <activity android:name=".ui.activity.ReadActivity" android:configChanges="orientation|screenSize"/>
         <activity android:name=".ui.activity.FileSystemActivity"/>
         <activity android:name=".ui.activity.CommunityActivity" />
         <activity android:name=".ui.activity.MoreSettingActivity" />


### PR DESCRIPTION
旋轉螢幕時 整個 UI 會被 destroy 並重新 init 造成大量的網路及資料庫 I/O
不是很確定哪個地方最後發生了問題 造成 app crash
暫時的解法是把 MainActivity 跟 ReadActivity 設為旋轉時不 destroy
其他 activity 沒有發現這個問題 所以沒有改動

Signed-off-by: AceLan Kao <acelan@acelan.idv.tw>