### PR TITLE
Update MainActivity.java

### DIFF
--- a/app/src/main/java/com/example/newbiechen/ireader/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/example/newbiechen/ireader/ui/activity/MainActivity.java
@@ -129,7 +129,7 @@ public class MainActivity extends BaseTabActivity{
                 break;
             case R.id.action_scan_local_book:
 
-                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M){
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
 
                     if (mPermissionsChecker == null){
                         mPermissionsChecker = new PermissionsChecker(this);


### PR DESCRIPTION
Android 6.0权限判断

这里动态权限申请判断Android版本时，少了“=”，导致Android6.0的手机没有申请权限闪退。